### PR TITLE
refactor(cdk-interop): update `focusMonitor`

### DIFF
--- a/projects/cdk-interop/focus-monitor/index.ts
+++ b/projects/cdk-interop/focus-monitor/index.ts
@@ -1,14 +1,14 @@
-import {
-  afterRenderEffect,
-  type EffectCleanupRegisterFn,
-  inject,
-  type Signal,
-  signal,
-} from '@angular/core';
+import { afterRenderEffect, computed, inject, type Signal, signal } from '@angular/core';
 import { FocusMonitor, type FocusOrigin } from '@angular/cdk/a11y';
 import type { Subscription } from 'rxjs';
-import { MaybeElementSignal, onDisconnect, WithInjector } from '@signality/core';
-import { constSignal, NOOP_FN, setupContext, toElement } from '@signality/core/internal';
+import { MaybeElementSignal, WithInjector } from '@signality/core';
+import {
+  assertElement,
+  constSignal,
+  NOOP_FN,
+  setupContext,
+  toElement,
+} from '@signality/core/internal';
 
 export interface FocusMonitorOptions extends WithInjector {
   /**
@@ -79,7 +79,7 @@ export function focusMonitor(
 ): FocusMonitorRef {
   const { runInContext } = setupContext(options?.injector, focusMonitor);
 
-  return runInContext(({ isServer, onCleanup }) => {
+  return runInContext(({ isServer }) => {
     if (isServer) {
       return {
         origin: constSignal(null),
@@ -91,57 +91,42 @@ export function focusMonitor(
     const cdkMonitor = inject(FocusMonitor);
 
     const origin = signal<FocusOrigin>(null);
-    const isFocused = signal(false);
+    const isFocused = computed(() => origin() !== null);
 
-    let subscription: Subscription | undefined;
+    let subscription: Subscription | null = null;
 
     const startMonitoring = (el: HTMLElement) => {
       subscription?.unsubscribe();
-
-      subscription = cdkMonitor.monitor(el, options?.checkChildren).subscribe(focusOrigin => {
-        origin.set(focusOrigin);
-        isFocused.set(focusOrigin !== null);
-      });
+      subscription = cdkMonitor.monitor(el, options?.checkChildren).subscribe(origin.set);
     };
 
     const stopMonitoring = (el: HTMLElement) => {
       origin.set(null);
-      isFocused.set(false);
       subscription?.unsubscribe();
+      subscription = null;
       cdkMonitor.stopMonitoring(el);
     };
 
     const focusVia = (origin: FocusOrigin, options?: FocusOptions) => {
-      const el = toElement.untracked(target);
-
-      if (!el) {
-        if (ngDevMode) {
-          console.warn('[focusMonitor] Cannot focus: element is not available');
-        }
-        return;
-      }
-
+      const el = toElement.untracked(target)!;
+      ngDevMode && assertElement(el, 'focusVia');
       cdkMonitor.focusVia(el, origin, options);
     };
 
-    const setupMonitoring = (onCleanup: EffectCleanupRegisterFn) => {
-      const el = toElement(target);
+    afterRenderEffect({
+      read: onCleanup => {
+        const el = toElement(target);
 
-      if (el) {
-        startMonitoring(el);
-        onCleanup(() => stopMonitoring(el));
-      }
-    };
-
-    onCleanup(() => subscription?.unsubscribe());
-
-    afterRenderEffect({ read: setupMonitoring });
-
-    onDisconnect(target, stopMonitoring);
+        if (el) {
+          startMonitoring(el);
+          onCleanup(() => stopMonitoring(el));
+        }
+      },
+    });
 
     return {
       origin: origin.asReadonly(),
-      isFocused: isFocused.asReadonly(),
+      isFocused,
       focusVia,
     };
   });


### PR DESCRIPTION
## Summary

Refactor `focusMonitor` utility to simplify subscription lifecycle management, use computed signal for `isFocused`, and delegate error handling to caller.

## What changed

**focusMonitor refactor:**
- Removed redundant `onCleanup(() => subscription?.unsubscribe())` — cleanup is already handled via `afterRenderEffect`'s registered cleanup that calls `stopMonitoring`
- Changed `isFocused` from `signal(false)` to `computed(() => origin() !== null)` — derived from `origin`
- Replaced local try/catch with `assertElement` call to delegate validation error to caller

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)
- [x] Follows existing code style and patterns

## Breaking changes

None