### PR TITLE
feat(core): `cva` replace generic CvaOptions type with explicit interface for better readability

### DIFF
--- a/projects/core/forms/cva/index.ts
+++ b/projects/core/forms/cva/index.ts
@@ -19,9 +19,16 @@ import { ALWAYS_FALSE_FN, setupContext } from '@signality/core/internal';
 import type { WithInjector } from '@signality/core/types';
 import { watcher } from '@signality/core/reactivity/watcher';
 
-export type CvaOptions<T> = Omit<Partial<MakeWritable<CvaRef<T>>>, 'value'> &
-  Pick<CvaRef<T>, 'value'> &
-  WithInjector;
+export interface CvaOptions<T> extends WithInjector {
+  readonly value: WritableSignal<T>;
+  readonly touched?: WritableSignal<boolean>;
+  readonly disabled?: WritableSignal<boolean>;
+  readonly required?: WritableSignal<boolean>;
+  readonly invalid?: WritableSignal<boolean>;
+  readonly pending?: WritableSignal<boolean>;
+  readonly dirty?: WritableSignal<boolean>;
+  readonly errors?: WritableSignal<ValidationErrors | null>;
+}
 
 export interface CvaRef<T> {
   readonly value: WritableSignal<T>;
@@ -195,7 +202,3 @@ export function cva<T>(options: CvaOptions<T>): CvaRef<T> {
     return cvaRef;
   });
 }
-
-type MakeWritable<T extends object> = {
-  [K in keyof T]: T[K] extends Signal<infer U> ? WritableSignal<U> : never;
-};

--- a/projects/docs/forms/cva.md
+++ b/projects/docs/forms/cva.md
@@ -31,7 +31,7 @@ import { cva } from '@signality/core';
   `,
 })
 export class CurrencyInput {
-  readonly value = model<number>(0);
+  readonly value = model(0);
   readonly cva = cva({ value: this.value }); // [!code highlight]
 
   readonly displayValue = computed(() => {
@@ -214,6 +214,17 @@ The `cva()` utility automatically integrates with Angular's form system:
 ## Type Definitions
 
 ```typescript
+interface CvaOptions<T> extends WithInjector {
+  readonly value: WritableSignal<T>;
+  readonly touched?: WritableSignal<boolean>;
+  readonly disabled?: WritableSignal<boolean>;
+  readonly required?: WritableSignal<boolean>;
+  readonly invalid?: WritableSignal<boolean>;
+  readonly pending?: WritableSignal<boolean>;
+  readonly dirty?: WritableSignal<boolean>;
+  readonly errors?: WritableSignal<ValidationErrors | null>;
+}
+
 interface CvaRef<T> {
   readonly value: WritableSignal<T>;
   readonly touched: WritableSignal<boolean>;
@@ -225,10 +236,6 @@ interface CvaRef<T> {
   readonly errors: Signal<ValidationErrors | null>;
   readonly reset: () => void;
 }
-
-type CvaOptions<T> = Omit<Partial<MakeWritable<CvaRef<T>>>, 'value'> &
-  Pick<CvaRef<T>, 'value'> &
-  WithInjector;
 
 function cva<T>(options: CvaOptions<T>): CvaRef<T>;
 ```


### PR DESCRIPTION
Closes: #127