### PR TITLE
feat(cdk-interop): add `SizeFnVirtualScroll` for varying size cdk vir…

### DIFF
--- a/projects/cdk-interop/index.ts
+++ b/projects/cdk-interop/index.ts
@@ -1,3 +1,4 @@
 export * from '@signality/cdk-interop/focus-monitor';
 export * from '@signality/cdk-interop/input-modality';
 export * from '@signality/cdk-interop/live-announcer';
+export * from '@signality/cdk-interop/virtual-scroll';

--- a/projects/cdk-interop/virtual-scroll/index.ts
+++ b/projects/cdk-interop/virtual-scroll/index.ts
@@ -1,0 +1,1 @@
+export * from '@signality/cdk-interop/virtual-scroll/size-fn-virtual-scroll';

--- a/projects/cdk-interop/virtual-scroll/ng-package.json
+++ b/projects/cdk-interop/virtual-scroll/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}
+

--- a/projects/cdk-interop/virtual-scroll/size-fn-virtual-scroll/index.ts
+++ b/projects/cdk-interop/virtual-scroll/size-fn-virtual-scroll/index.ts
@@ -1,0 +1,3 @@
+export type * from './virtual-scroll-item-size-fn';
+export * from './size-fn-virtual-scroll-strategy';
+export * from './size-fn-virtual-scroll';

--- a/projects/cdk-interop/virtual-scroll/size-fn-virtual-scroll/ng-package.json
+++ b/projects/cdk-interop/virtual-scroll/size-fn-virtual-scroll/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}
+

--- a/projects/cdk-interop/virtual-scroll/size-fn-virtual-scroll/size-fn-virtual-scroll-strategy.ts
+++ b/projects/cdk-interop/virtual-scroll/size-fn-virtual-scroll/size-fn-virtual-scroll-strategy.ts
@@ -1,0 +1,218 @@
+/**
+ * Based on:
+ * https://github.com/angular/components/blob/main/src/cdk/scrolling/fixed-size-virtual-scroll.ts
+ */
+
+import type { CdkVirtualScrollViewport, VirtualScrollStrategy } from '@angular/cdk/scrolling';
+import { distinctUntilChanged, Subject } from 'rxjs';
+import type { VirtualScrollItemSizeFn } from './virtual-scroll-item-size-fn';
+
+export class SizeFnVirtualScrollStrategy implements VirtualScrollStrategy {
+  private readonly _scrolledIndexChange = new Subject<number>();
+
+  readonly scrolledIndexChange = this._scrolledIndexChange.pipe(distinctUntilChanged());
+
+  private viewport: CdkVirtualScrollViewport | undefined = undefined;
+
+  constructor(
+    private itemSizeFn: VirtualScrollItemSizeFn,
+    private minBufferPx: number,
+    private maxBufferPx: number
+  ) {}
+
+  attach(viewport: CdkVirtualScrollViewport): void {
+    this.viewport = viewport;
+
+    this.updateTotalContentSize();
+    this.updateRenderedRange();
+  }
+
+  detach(): void {
+    this._scrolledIndexChange.complete();
+    this.viewport = undefined;
+  }
+
+  updateItemAndBufferSize(
+    itemSizeFn: VirtualScrollItemSizeFn,
+    minBufferPx: number,
+    maxBufferPx: number
+  ) {
+    this.itemSizeFn = itemSizeFn;
+    this.minBufferPx = minBufferPx;
+    this.maxBufferPx = maxBufferPx;
+
+    this.updateTotalContentSize();
+    this.updateRenderedRange();
+  }
+
+  onContentScrolled(): void {
+    this.updateRenderedRange();
+  }
+
+  onDataLengthChanged(): void {
+    this.updateTotalContentSize();
+    this.updateRenderedRange();
+  }
+
+  onContentRendered(): void {
+    // no-op
+  }
+
+  onRenderedOffsetChanged(): void {
+    // no-op
+  }
+
+  scrollToIndex(index: number, behavior: ScrollBehavior): void {
+    if (!this.viewport) {
+      return;
+    }
+
+    this.viewport.scrollToOffset(this.findOffsetToIndex(index, this.viewport), behavior);
+  }
+
+  private updateTotalContentSize() {
+    if (!this.viewport) {
+      return;
+    }
+
+    this.viewport.setTotalContentSize(
+      this.findOffsetToIndex(this.viewport.getDataLength(), this.viewport)
+    );
+  }
+
+  private updateRenderedRange() {
+    if (!this.viewport) {
+      return;
+    }
+
+    const renderedRange = this.viewport.getRenderedRange();
+    const newRange = { start: renderedRange.start, end: renderedRange.end };
+    const viewportSize = this.viewport.getViewportSize();
+    const dataLength = this.viewport.getDataLength();
+    let scrollOffset = this.viewport.measureScrollOffset();
+
+    let firstVisibleIndex = this.findIndexByOffset(scrollOffset, this.viewport);
+
+    if (newRange.end > dataLength) {
+      const newVisibleIndex = Math.max(
+        0,
+        Math.min(firstVisibleIndex, this.indexBeforeSize(dataLength, viewportSize, this.viewport))
+      );
+
+      if (firstVisibleIndex !== newVisibleIndex) {
+        firstVisibleIndex = newVisibleIndex;
+        scrollOffset = this.findOffsetToIndex(firstVisibleIndex, this.viewport);
+        newRange.start = firstVisibleIndex;
+      }
+
+      newRange.end = Math.min(
+        dataLength,
+        this.indexAfterSize(newRange.start, viewportSize, this.viewport)
+      );
+    }
+
+    const startBuffer = scrollOffset - this.findOffsetToIndex(newRange.start, this.viewport);
+
+    if (startBuffer < this.minBufferPx && newRange.start !== 0) {
+      newRange.start = this.indexBeforeSize(
+        newRange.start,
+        this.maxBufferPx - startBuffer,
+        this.viewport
+      );
+
+      newRange.end = Math.min(
+        dataLength,
+        this.indexAfterSize(firstVisibleIndex, viewportSize + this.minBufferPx, this.viewport)
+      );
+    } else {
+      const endBuffer =
+        this.findOffsetToIndex(newRange.end, this.viewport) - (scrollOffset + viewportSize);
+
+      if (endBuffer < this.minBufferPx && newRange.end !== dataLength) {
+        newRange.end = Math.min(
+          dataLength,
+          this.indexAfterSize(newRange.end, this.maxBufferPx - endBuffer, this.viewport)
+        );
+
+        newRange.start = Math.max(
+          0,
+          this.indexBeforeSize(firstVisibleIndex, this.minBufferPx, this.viewport)
+        );
+      }
+    }
+
+    this.viewport.setRenderedRange(newRange);
+    this.viewport.setRenderedContentOffset(this.findOffsetToIndex(newRange.start, this.viewport));
+    this._scrolledIndexChange.next(firstVisibleIndex);
+  }
+
+  /**
+   * Find which index is {@link offset} size away from the first index
+   */
+  private findIndexByOffset(offset: number, viewport: CdkVirtualScrollViewport) {
+    const dataLength = viewport.getDataLength();
+    let accumulatedOffset = 0;
+
+    for (let i = 0; i < dataLength; i++) {
+      accumulatedOffset += this.itemSizeFn(i, dataLength);
+
+      if (accumulatedOffset > offset) {
+        return i;
+      }
+    }
+
+    return Math.max(0, dataLength - 1);
+  }
+
+  /**
+   * Find the total size between the first item and the item in {@link index}
+   */
+  private findOffsetToIndex(index: number, viewport: CdkVirtualScrollViewport) {
+    const dataLength = viewport.getDataLength();
+    let offset = 0;
+
+    for (let i = 0; i < index; i++) {
+      offset += this.itemSizeFn(i, dataLength);
+    }
+
+    return offset;
+  }
+
+  /**
+   * Find which index after {@link fromIndex} is {@link size} away from it
+   */
+  private indexAfterSize(
+    fromIndex: number,
+    size: number,
+    viewport: CdkVirtualScrollViewport
+  ): number {
+    const dataLength = viewport.getDataLength();
+    let covered = 0;
+    let i = fromIndex;
+
+    while (i < dataLength && covered < size) {
+      covered += this.itemSizeFn(i++, dataLength);
+    }
+
+    return i;
+  }
+
+  /**
+   * Find which index before {@link fromIndex} is {@link size} away from it
+   */
+  private indexBeforeSize(
+    fromIndex: number,
+    size: number,
+    viewport: CdkVirtualScrollViewport
+  ): number {
+    const dataLength = viewport.getDataLength();
+    let covered = 0;
+    let i = fromIndex;
+
+    while (i > 0 && covered < size) {
+      covered += this.itemSizeFn(--i, dataLength);
+    }
+
+    return i;
+  }
+}

--- a/projects/cdk-interop/virtual-scroll/size-fn-virtual-scroll/size-fn-virtual-scroll.ts
+++ b/projects/cdk-interop/virtual-scroll/size-fn-virtual-scroll/size-fn-virtual-scroll.ts
@@ -1,0 +1,96 @@
+import { Directive, inject, input, numberAttribute, effect, computed } from '@angular/core';
+import type { VirtualScrollItemSizeFn } from './virtual-scroll-item-size-fn';
+import { VIRTUAL_SCROLL_STRATEGY } from '@angular/cdk/scrolling';
+import { SizeFnVirtualScrollStrategy } from './size-fn-virtual-scroll-strategy';
+
+/**
+ * Signal based directive for applying a varying itemSize virtual scroll strategy on [CdkVirtualScrollViewport](https://material.angular.dev/cdk/scrolling/api#CdkVirtualScrollViewport).
+ *
+ * @example
+ * ```angular-ts
+ * import { ScrollingModule } from '@angular/cdk/scrolling';
+ * import { Component } from '@angular/core';
+ * import { SizeFnVirtualScroll } from '@signality/cdk-interop';
+ *
+ * @Component({
+ *   template: `
+ *     <cdk-virtual-scroll-viewport [itemSizeFn]="itemSizeFn" [gap]="gap">
+ *       <div
+ *         *cdkVirtualFor="let item of items; let i = index; let last = last"
+ *         [style.height.px]="itemSizeFn(i)"
+ *         [style.margin-bottom.px]="last ? 0 : gap"
+ *       >
+ *         {{ item }}
+ *       </div>
+ *     </cdk-virtual-scroll-viewport>
+ *   `,
+ *   imports: [ScrollingModule, SizeFnVirtualScroll],
+ * })
+ * export class FocusDemo {
+ *   protected readonly items = Array.from({ length: 100_000 }).map((_, i) => `Item #${i}`);
+ *   protected readonly gap = 10;
+ *   protected readonly itemSizeFn = (index: number) => (index % 2 === 0 ? 50 : 30);
+ * }
+ * ```
+ */
+@Directive({
+  selector: 'cdk-virtual-scroll-viewport[itemSizeFn]',
+  providers: [
+    {
+      provide: VIRTUAL_SCROLL_STRATEGY,
+      useFactory: () => inject(SizeFnVirtualScroll)._scrollStrategy,
+    },
+  ],
+})
+export class SizeFnVirtualScroll {
+  private readonly defaultItemSizeFn: VirtualScrollItemSizeFn = () => 20;
+  private readonly defaultMinBufferPx = 100;
+  private readonly defaultMaxBufferPx = 200;
+
+  readonly itemSizeFn = input(this.defaultItemSizeFn);
+  readonly gap = input(0, { transform: numberAttribute });
+  readonly paddingTop = input(0, { transform: numberAttribute });
+  readonly paddingBottom = input(0, { transform: numberAttribute });
+  readonly minBufferPx = input(this.defaultMinBufferPx, { transform: numberAttribute });
+  readonly maxBufferPx = input(this.defaultMaxBufferPx, { transform: numberAttribute });
+
+  private readonly totalItemSizeFn = computed((): VirtualScrollItemSizeFn => {
+    const itemSizeFn = this.itemSizeFn();
+    const gap = this.gap();
+    const paddingTop = this.paddingTop();
+    const paddingBottom = this.paddingBottom();
+
+    return (index, dataLength) => {
+      const initialSize = itemSizeFn(index, dataLength);
+
+      if (index === 0) {
+        return paddingTop + initialSize + gap;
+      }
+
+      if (index === dataLength - 1) {
+        return initialSize + paddingBottom;
+      }
+
+      return initialSize + gap;
+    };
+  });
+
+  /**
+   * @internal
+   */
+  readonly _scrollStrategy = new SizeFnVirtualScrollStrategy(
+    this.defaultItemSizeFn,
+    this.defaultMinBufferPx,
+    this.defaultMaxBufferPx
+  );
+
+  constructor() {
+    effect(() =>
+      this._scrollStrategy.updateItemAndBufferSize(
+        this.totalItemSizeFn(),
+        this.minBufferPx(),
+        this.maxBufferPx()
+      )
+    );
+  }
+}

--- a/projects/cdk-interop/virtual-scroll/size-fn-virtual-scroll/virtual-scroll-item-size-fn.ts
+++ b/projects/cdk-interop/virtual-scroll/size-fn-virtual-scroll/virtual-scroll-item-size-fn.ts
@@ -1,0 +1,1 @@
+export type VirtualScrollItemSizeFn = (index: number, dataLength: number) => number;

--- a/projects/demos/src/app/demo-routes.ts
+++ b/projects/demos/src/app/demo-routes.ts
@@ -326,4 +326,12 @@ export const DEMO_ROUTES: Route[] = [
     loadComponent: () =>
       import('../demos/window-size/window-size-demo').then(m => m.WindowSizeDemo),
   },
+  {
+    path: 'size-fn-virtual-scroll',
+    title: 'SizeFnVirtualScroll',
+    loadComponent: () =>
+      import('../demos/size-fn-virtual-scroll/size-fn-virtual-scroll-demo').then(
+        m => m.SizeFnVirtualScrollDemo
+      ),
+  },
 ];

--- a/projects/demos/src/demos/size-fn-virtual-scroll/size-fn-virtual-scroll-demo.html
+++ b/projects/demos/src/demos/size-fn-virtual-scroll/size-fn-virtual-scroll-demo.html
@@ -1,0 +1,36 @@
+<ng-demo-wrapper [demoPath]="'size-fn-virtual-scroll/size-fn-virtual-scroll-demo'" [code]="importCode">
+  <demo-card>
+    <div class="size-controls">
+      <span class="label">evenItemSize</span>
+      <input type="number" min="0" demoInput placeholder="Even items size" [(ngModel)]="evenItemSize" />
+      <span class="label">oddItemSize</span>
+      <input type="number" min="0" demoInput placeholder="Odd items size" [(ngModel)]="oddItemSize" />
+      <span class="label">gap</span>
+      <input type="number" min="0" demoInput placeholder="Gap" [(ngModel)]="gap" />
+      <span class="label">paddingTop</span>
+      <input type="number" min="0" demoInput placeholder="Padding top" [(ngModel)]="paddingTop" />
+      <span class="label">paddingBottom</span>
+      <input type="number" min="0" demoInput placeholder="Padding bottom" [(ngModel)]="paddingBottom" />
+    </div>
+    <div class="scroll-to">
+      <input #scrollToNgModel="ngModel" type="number" demoInput placeholder="Index to scroll to" min="0" [max]="items.length - 1" [(ngModel)]="indexToScrollTo" />
+      <button class="btn" [disabled]="!scrollToNgModel.valid" (click)="viewport.scrollToIndex(indexToScrollTo())">Scroll To Index</button>
+    </div>
+    <cdk-virtual-scroll-viewport #viewport
+      [itemSizeFn]="itemSizeFn()"
+      [gap]="gap()"
+      [paddingTop]="paddingTop()"
+      [paddingBottom]="paddingBottom()"
+    >
+      <div
+        *cdkVirtualFor="let item of items; let i = index; let last = last; let first = first"
+        class="item"
+        [style.height.px]="itemSizeFn()(i, items.length)"
+        [style.margin-bottom.px]="last ? paddingBottom() : gap()"
+        [style.margin-top.px]="first ? paddingTop() : 0"
+      >
+        {{ item }}
+      </div>
+    </cdk-virtual-scroll-viewport>
+  </demo-card>
+</ng-demo-wrapper>

--- a/projects/demos/src/demos/size-fn-virtual-scroll/size-fn-virtual-scroll-demo.scss
+++ b/projects/demos/src/demos/size-fn-virtual-scroll/size-fn-virtual-scroll-demo.scss
@@ -1,0 +1,62 @@
+.size-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  & > input {
+    flex: 1;
+    min-width: 150px;
+  }
+
+  .label {
+    font-size: 0.8125rem;
+    color: #71717a;
+    display: flex;
+    align-items: center;
+  }
+}
+
+.scroll-to {
+  display: flex;
+  align-items: center;
+  margin-top: 20px;
+
+  & > input {
+    max-width: 150px;
+    margin-right: 10px;
+  }
+}
+
+.btn {
+  font-size: 0.8125rem;
+  font-family: inherit;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: #deb3eb;
+  transition: color 0.15s ease;
+
+  &:hover {
+    color: #e8c8f5;
+  }
+
+  &:disabled {
+    color: #52525b;
+    cursor: default;
+  }
+}
+
+cdk-virtual-scroll-viewport {
+  height: 400px;
+  margin-top: 20px;
+  border: 1px solid #71717a;
+  border-radius: 4px;
+  color: #e4e4e7;
+}
+
+.item {
+  border: 1px solid #71717a;
+  border-radius: 4px;
+  margin: 0 5px;
+}

--- a/projects/demos/src/demos/size-fn-virtual-scroll/size-fn-virtual-scroll-demo.ts
+++ b/projects/demos/src/demos/size-fn-virtual-scroll/size-fn-virtual-scroll-demo.ts
@@ -1,0 +1,32 @@
+import { ChangeDetectionStrategy, Component, computed, signal } from '@angular/core';
+import { DemoCard, DemoInput, Wrapper } from '../../common';
+import { SizeFnVirtualScroll, VirtualScrollItemSizeFn } from '@signality/cdk-interop';
+import { ScrollingModule } from '@angular/cdk/scrolling';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'demo-size-fn-virtual-scroll',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [Wrapper, DemoCard, DemoInput, ScrollingModule, SizeFnVirtualScroll, FormsModule],
+  templateUrl: './size-fn-virtual-scroll-demo.html',
+  styleUrl: './size-fn-virtual-scroll-demo.scss',
+})
+export class SizeFnVirtualScrollDemo {
+  readonly importCode = `import { SizeFnVirtualScroll } from '@signality/cdk-interop'`;
+
+  evenItemSize = signal(30);
+  oddItemSize = signal(50);
+  gap = signal(10);
+  paddingTop = signal(5);
+  paddingBottom = signal(5);
+  indexToScrollTo = signal(0);
+
+  itemSizeFn = computed((): VirtualScrollItemSizeFn => {
+    const evenItemSize = this.evenItemSize();
+    const oddItemSize = this.oddItemSize();
+
+    return index => (index % 2 === 0 ? evenItemSize : oddItemSize);
+  });
+
+  protected readonly items = Array.from({ length: 100_000 }).map((_, i) => `Item #${i}`);
+}

--- a/projects/demos/src/main.elements.ts
+++ b/projects/demos/src/main.elements.ts
@@ -67,6 +67,7 @@ import { WindowSizeDemo } from './demos/window-size/window-size-demo';
 import { ScreenOrientationDemo } from './demos/screen-orientation/screen-orientation-demo';
 import { DevicePixelRatioDemo } from './demos/device-pixel-ratio/device-pixel-ratio-demo';
 import { GenerateIdDemo } from './demos/generate-id/generate-id-demo';
+import { SizeFnVirtualScrollDemo } from './demos/size-fn-virtual-scroll/size-fn-virtual-scroll-demo';
 
 const DEMOS = [
   { component: ActiveElementDemo, name: 'signality-demo-active-element' },
@@ -124,6 +125,7 @@ const DEMOS = [
   { component: WebWorkerDemo, name: 'signality-demo-web-worker' },
   { component: WindowFocusDemo, name: 'signality-demo-window-focus' },
   { component: WindowSizeDemo, name: 'signality-demo-window-size' },
+  { component: SizeFnVirtualScrollDemo, name: 'signality-demo-size-fn-virtual-scroll' },
 ] as const;
 
 (async () => {

--- a/projects/docs/.vitepress/config.ts
+++ b/projects/docs/.vitepress/config.ts
@@ -281,6 +281,15 @@ export default defineConfig({
           { text: 'FocusMonitor', link: '/cdk-interop/focus-monitor' },
           { text: 'InputModality', link: '/cdk-interop/input-modality' },
           { text: 'LiveAnnouncer', link: '/cdk-interop/live-announcer' },
+          {
+            text: 'VirtualScroll', 
+            items: [
+              {
+                text: 'SizeFnVirtualScroll',
+                link: '/cdk-interop/virtual-scroll/size-fn-virtual-scroll'
+              }
+            ]
+          },
         ],
       },
       {

--- a/projects/docs/.vitepress/config/new-items.ts
+++ b/projects/docs/.vitepress/config/new-items.ts
@@ -3,7 +3,8 @@ export const NEW_ITEMS = [
   '/browser/text-selection',
   '/browser/device-pixel-ratio',
   '/elements/element-focus',
-  '/utilities/generate-id'
+  '/utilities/generate-id',
+  '/cdk-interop/virtual-scroll/size-fn-virtual-scroll'
 ];
 
 export function isNew(link: string): boolean {

--- a/projects/docs/cdk-interop/virtual-scroll/size-fn-virtual-scroll.md
+++ b/projects/docs/cdk-interop/virtual-scroll/size-fn-virtual-scroll.md
@@ -1,0 +1,142 @@
+---
+source: https://github.com/signalityjs/signality/blob/main/projects/cdk-interop/virtual-scroll/size-fn-virtual-scroll/index.ts
+---
+
+# SizeFnVirtualScroll
+
+Signal based directive for applying a varying itemSize virtual scroll strategy on [CdkVirtualScrollViewport](https://material.angular.dev/cdk/scrolling/api#CdkVirtualScrollViewport).
+The directive allows passing an itemSizeFn and optional minBufferPx, maxBufferPx, gap, paddingTop, paddingBottom.
+
+::: warning CDK Interop Package Required
+This utility requires the `@signality/cdk-interop` and `@angular/cdk` packages to be installed:
+
+```bash
+npm install @signality/cdk-interop @angular/cdk
+```
+
+:::
+
+## Usage
+```angular-ts
+import { ScrollingModule } from '@angular/cdk/scrolling';
+import { Component } from '@angular/core';
+import { SizeFnVirtualScroll } from '@signality/cdk-interop';
+
+@Component({
+  template: `
+    <cdk-virtual-scroll-viewport [itemSizeFn] ="itemSizeFn" [gap]="gap">
+      <div
+        *cdkVirtualFor="let item of items; let i = index; let last = last"
+        [style.height.px]="itemSizeFn(i)"
+        [style.margin-bottom.px]="last ? 0 : gap"
+      >
+        {{ item }}
+      </div>
+    </cdk-virtual-scroll-viewport>
+  `,
+  imports: [ScrollingModule, SizeFnVirtualScroll],
+})
+export class FocusDemo {
+  protected readonly items = Array.from({ length: 100_000 }).map((_, i) => `Item #${i}`);
+  protected readonly gap = 10;
+  protected readonly itemSizeFn = (index: number) => (index % 2 === 0 ? 50 : 30);
+}
+```
+
+## Inputs
+| Input | Type | Description |
+|-------|------|-------------|
+| `itemSizeFn`    | `VirtualScrollItemSizeFn`   | The varying item size fn that decides the size of each item given `index` and `dataLength` |
+| `gap`    | `number`   | The gap between items |
+| `paddingTop`    | `number`   | The padding above the first item |
+| `paddingBottom`    | `number`   | The padding below the last item |
+| `minBufferPx`    | `number`   | Exactly the same as [FixedSizeVirtualScrollStrategy](https://material.angular.dev/cdk/scrolling/api#FixedSizeVirtualScrollStrategy) |
+| `maxBufferPx`    | `number`   | Exactly the same as [FixedSizeVirtualScrollStrategy](https://material.angular.dev/cdk/scrolling/api#FixedSizeVirtualScrollStrategy) |
+
+## Examples
+
+### Fixed size
+```angular-ts
+import { ScrollingModule } from '@angular/cdk/scrolling';
+import { Component } from '@angular/core';
+import { SizeFnVirtualScroll } from '@signality/cdk-interop';
+
+@Component({
+  template: `
+    <cdk-virtual-scroll-viewport [itemSizeFn]="itemSizeFn">
+      <div *cdkVirtualFor="let item of items; let i = index" [style.height.px]="itemSize">
+        {{ item }}
+      </div>
+    </cdk-virtual-scroll-viewport>
+  `,
+  imports: [ScrollingModule, SizeFnVirtualScroll],
+})
+export class FocusDemo {
+  protected readonly items = Array.from({ length: 100_000 }).map((_, i) => `Item #${i}`);
+  protected readonly itemSize = 50;
+  protected readonly itemSizeFn = () => this.itemSize;
+}
+```
+
+### Dynamic size
+```angular-ts
+import { ScrollingModule } from '@angular/cdk/scrolling';
+import { Component } from '@angular/core';
+import { SizeFnVirtualScroll } from '@signality/cdk-interop';
+
+@Component({
+  template: `
+    <cdk-virtual-scroll-viewport [itemSizeFn]="itemSizeFn">
+      <div *cdkVirtualFor="let item of items; let i = index" [style.height.px]="itemSizeFn(i)">
+        {{ item }}
+      </div>
+    </cdk-virtual-scroll-viewport>
+  `,
+  imports: [ScrollingModule, SizeFnVirtualScroll],
+})
+export class FocusDemo {
+  protected readonly items = Array.from({ length: 100_000 }).map((_, i) => `Item #${i}`);
+  protected readonly itemSizeFn = (index: number) => (index % 2 === 0 ? 50 : 30);
+}
+```
+
+### Dynamic size with gap, padding
+```angular-ts
+import { ScrollingModule } from '@angular/cdk/scrolling';
+import { Component } from '@angular/core';
+import { SizeFnVirtualScroll } from '@signality/cdk-interop';
+
+@Component({
+  template: `
+    <cdk-virtual-scroll-viewport
+      [itemSizeFn]="itemSizeFn"
+      [gap]="gap"
+      [paddingTop]="paddingTop"
+      [paddingBottom]="paddingBottom"
+    >
+      <div
+        *cdkVirtualFor="let item of items; let i = index; let last = last; let first = first"
+        [style.height.px]="itemSizeFn(i)"
+        [style.margin-bottom.px]="last ? paddingBottom : gap"
+        [style.margin-top.px]="first ? paddingTop : 0"
+      >
+        {{ item }}
+      </div>
+    </cdk-virtual-scroll-viewport>
+  `,
+  imports: [ScrollingModule, SizeFnVirtualScroll],
+})
+export class FocusDemo {
+  protected readonly items = Array.from({ length: 100_000 }).map((_, i) => `Item #${i}`);
+  protected readonly gap = 10;
+  protected readonly paddingTop = 20;
+  protected readonly paddingBottom = 20;
+  protected readonly itemSizeFn = (index: number) => (index % 2 === 0 ? 50 : 30);
+}
+```
+
+## Type Definitions
+
+```typescript
+type VirtualScrollItemSizeFn = (index: number, dataLength: number) => number;
+```


### PR DESCRIPTION
…tual scroll items

Closes: #151

## Summary

Adds a new `SizeFnVirtualScrollStrategy` with a complimenting directive `SizeFnVirtualScroll` with usage similar to angular cdk `[itemSize]` but instead allows `[itemSizeFn]`.

## What changed

- cdk-interop: Added a new `virtual-scroll` folder with `item-size-virtual-scroll` inside as we might have more virtual scroll related features later on.
- docs: Added documentation for the new `SizeFnVirtualScroll` directive.
- demo: Added a new demo to showcase some of the features provided by the new `SizeFnVirtualScroll` directive.

## Checklist

- [ ] Tests added/updated
- [x] Documentation updated (if applicable)
- [x] Follows existing code style and patterns

## Breaking changes

None
