### PR TITLE
feat(core): enhance `fragment` with writable signal

### DIFF
--- a/projects/core/router/fragment/index.test.ts
+++ b/projects/core/router/fragment/index.test.ts
@@ -1,48 +1,48 @@
 import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { ActivatedRoute } from '@angular/router';
-import { BehaviorSubject } from 'rxjs';
+import { provideRouter, Router } from '@angular/router';
 import { fragment } from './index';
 
 describe(fragment.name, () => {
-  let fragmentState: BehaviorSubject<string | null>;
-
-  beforeEach(() => {
-    fragmentState = new BehaviorSubject<string | null>(null);
-
-    TestBed.configureTestingModule({
-      providers: [
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            fragment: fragmentState.asObservable(),
-            snapshot: { fragment: fragmentState.getValue() },
-          },
-        },
-      ],
-    });
-  });
-
   @Component({ template: '#{{ currentFragment() }}' })
   class TestComponent {
     readonly currentFragment = fragment();
   }
 
-  it('should update when fragment changes', () => {
-    fragmentState.next('section1');
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideRouter([{ path: '**', component: TestComponent }])],
+    });
+  });
+
+  it('should update when fragment changes', async () => {
+    const router = TestBed.inject(Router);
     const fixture = TestBed.createComponent(TestComponent);
     const component = fixture.componentInstance;
     fixture.detectChanges();
 
+    await router.navigate([], { fragment: 'section1' });
     expect(component.currentFragment()).toBe('section1');
 
-    fragmentState.next('section2');
+    await router.navigate([], { fragment: 'section2' });
     expect(component.currentFragment()).toBe('section2');
 
-    fragmentState.next('section3');
-    expect(component.currentFragment()).toBe('section3');
-
-    fragmentState.next(null);
+    await router.navigate([], { fragment: undefined });
     expect(component.currentFragment()).toBe(null);
+  });
+
+  it('should write a new fragment', async () => {
+    const router = TestBed.inject(Router);
+    const fixture = TestBed.createComponent(TestComponent);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.currentFragment.set('section-1');
+    await fixture.whenStable();
+    expect(router.url).toContain('#section-1');
+
+    component.currentFragment.update(curr => curr?.slice(0, -1) + '2');
+    await fixture.whenStable();
+    expect(router.url).toContain('#section-2');
   });
 });

--- a/projects/core/router/fragment/index.ts
+++ b/projects/core/router/fragment/index.ts
@@ -47,11 +47,11 @@ export function fragment(options?: FragmentOptions): WritableSignal<string | nul
     const writableFragment = linkedSignal(() => fragment());
 
     effect(() => {
-      const updated = writableFragment() ?? undefined;
+      const updated = writableFragment();
       // to prevent a navigation on initialization if the URL already has a fragment
       if (updated !== fragment())
         router.navigate([], {
-          fragment: updated,
+          fragment: updated ?? undefined,
           replaceUrl: options?.replaceUrl,
           queryParamsHandling: 'preserve',
         });

--- a/projects/core/router/fragment/index.ts
+++ b/projects/core/router/fragment/index.ts
@@ -1,16 +1,24 @@
-import { type CreateSignalOptions, inject, type Signal } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import {
+  effect,
+  inject,
+  linkedSignal,
+  type CreateSignalOptions,
+  type WritableSignal,
+} from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router, type NavigationExtras } from '@angular/router';
 import { setupContext } from '@signality/core/internal';
 import type { WithInjector } from '@signality/core/types';
 
-export type FragmentOptions = CreateSignalOptions<string | null> & WithInjector;
+export type FragmentOptions = CreateSignalOptions<string | null> &
+  WithInjector &
+  Pick<NavigationExtras, 'replaceUrl'>;
 
 /**
  * Reactive wrapper around the [Angular Router](https://angular.dev/guide/routing) URL fragment.
  *
- * @param options - Optional configuration including signal options and injector
- * @returns A signal containing the current URL fragment (without #), or null
+ * @param options - Optional configuration including signal options, injector and navigation behavior
+ * @returns A writable signal containing the current URL fragment (without #), or null
  *
  * @example
  * ```typescript
@@ -28,12 +36,27 @@ export type FragmentOptions = CreateSignalOptions<string | null> & WithInjector;
  * }
  * ```
  */
-export function fragment(options?: FragmentOptions): Signal<string | null> {
+export function fragment(options?: FragmentOptions): WritableSignal<string | null> {
   const { runInContext } = setupContext(options?.injector, fragment);
 
   return runInContext(() => {
+    const router = inject(Router);
     const { fragment: fragmentChanges, snapshot } = inject(ActivatedRoute);
 
-    return toSignal(fragmentChanges, { ...options, initialValue: snapshot.fragment });
+    const fragment = toSignal(fragmentChanges, { ...options, initialValue: snapshot.fragment });
+    const writableFragment = linkedSignal(() => fragment());
+
+    effect(() => {
+      const updated = writableFragment() ?? undefined;
+      // to prevent a navigation on initialization if the URL already has a fragment
+      if (updated !== fragment())
+        router.navigate([], {
+          fragment: updated,
+          replaceUrl: options?.replaceUrl,
+          queryParamsHandling: 'preserve',
+        });
+    });
+
+    return writableFragment;
   });
 }

--- a/projects/core/router/fragment/index.ts
+++ b/projects/core/router/fragment/index.ts
@@ -1,13 +1,7 @@
-import {
-  effect,
-  inject,
-  linkedSignal,
-  type CreateSignalOptions,
-  type WritableSignal,
-} from '@angular/core';
+import { inject, linkedSignal, type CreateSignalOptions, type WritableSignal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, type NavigationExtras } from '@angular/router';
-import { setupContext } from '@signality/core/internal';
+import { proxySignal, setupContext } from '@signality/core/internal';
 import type { WithInjector } from '@signality/core/types';
 
 export type FragmentOptions = CreateSignalOptions<string | null> &
@@ -43,20 +37,19 @@ export function fragment(options?: FragmentOptions): WritableSignal<string | nul
     const router = inject(Router);
     const { fragment: fragmentChanges, snapshot } = inject(ActivatedRoute);
 
-    const fragment = toSignal(fragmentChanges, { ...options, initialValue: snapshot.fragment });
-    const writableFragment = linkedSignal(() => fragment());
+    const fragment = linkedSignal(
+      toSignal(fragmentChanges, { ...options, initialValue: snapshot.fragment })
+    );
 
-    effect(() => {
-      const updated = writableFragment();
-      // to prevent a navigation on initialization if the URL already has a fragment
-      if (updated !== fragment())
-        router.navigate([], {
-          fragment: updated ?? undefined,
+    return proxySignal(fragment, {
+      set: async (fragment, source) => {
+        const succeeded = await router.navigate([], {
+          fragment: fragment ?? undefined,
           replaceUrl: options?.replaceUrl,
           queryParamsHandling: 'preserve',
         });
+        if (succeeded) source.set(fragment);
+      },
     });
-
-    return writableFragment;
   });
 }

--- a/projects/docs/router/fragment.md
+++ b/projects/docs/router/fragment.md
@@ -4,7 +4,7 @@ source: https://github.com/signalityjs/signality/blob/main/projects/core/router/
 
 # Fragment
 
-Reactive wrapper around Angular Router's [URL fragment](https://angular.dev/api/router/ActivatedRoute#fragment). Access the hash fragment as a signal.
+Reactive wrapper around Angular Router's [URL fragment](https://angular.dev/api/router/ActivatedRoute#fragment). Access the hash fragment as a writable signal.
 
 ## Usage
 
@@ -37,15 +37,45 @@ export class ProductPage {
 
 The `FragmentOptions` extends [`CreateSignalOptions<string | null>`](https://angular.dev/api/core/CreateSignalOptions) and `WithInjector`:
 
-| Option      | Type                                                                              | Default | Description                                                                                        |
-|-------------|-----------------------------------------------------------------------------------|---------|----------------------------------------------------------------------------------------------------|
-| `equal`     | [`ValueEqualityFn<string \| null>`](https://angular.dev/api/core/ValueEqualityFn) | -       | Custom equality function ([see more](https://angular.dev/guide/signals#signal-equality-functions)) |
-| `debugName` | `string`                                                                          | -       | Debug name for the signal (development only)                                                       |
-| `injector`  | [`Injector`](https://angular.dev/api/core/Injector)                               | -       | Optional injector for DI context                                                                   |
+| Option       | Type                                                                              | Default | Description                                                                                                                                                                                     |
+|--------------|-----------------------------------------------------------------------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `equal`      | [`ValueEqualityFn<string \| null>`](https://angular.dev/api/core/ValueEqualityFn) | -       | Custom equality function ([see more](https://angular.dev/guide/signals#signal-equality-functions))                                                                                              |
+| `debugName`  | `string`                                                                          | -       | Debug name for the signal (development only)                                                                                                                                                    |
+| `injector`   | [`Injector`](https://angular.dev/api/core/Injector)                               | -       | Optional injector for DI context                                                                                                                                                                |
+| `replaceUrl` | `boolean`                                                                         | `false` | When `true`, updating the fragment will replace the current state in history. ([see more](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState)) |
 
 ## Return Value
 
-Returns a `Signal<string | null>` containing the current URL fragment (without the `#`), or `null` if no fragment exists.
+Returns a `WritableSignal<string | null>` containing the current URL fragment (without the `#`), or `null` if no fragment exists.
+
+## Examples
+
+### With `{ replaceUrl: true }`
+
+```angular-ts
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { fragment } from '@signality/core';
+
+@Component({
+  imports: [FormsModule],
+  template: `
+    <nav>
+      <!-- Same as <select [ngModel]="fragment()" (ngModelChange)="fragment.set($event)"> -->
+      <select [(ngModel)]="fragment"> <!-- [!code highlight] -->
+        <option value="section-1">Section 1</option>
+        <option value="section-2">Section 2</option>
+      </select>
+    </nav>
+
+    <section id="section-1">...</section>
+    <section id="section-2">...</section>
+  `,
+})
+export class ProductPage {
+  readonly fragment = fragment({ replaceUrl: true }); // [!code highlight]
+}
+```
 
 ## SSR Compatibility
 
@@ -54,9 +84,11 @@ On the server, the signal initializes with the fragment from the [snapshot](http
 ## Type Definitions
 
 ```typescript
-type FragmentOptions = CreateSignalOptions<string | null> & WithInjector;
+type FragmentOptions = CreateSignalOptions<string | null> &
+  WithInjector &
+  Pick<NavigationExtras, 'replaceUrl'>;
 
-function fragment(options?: FragmentOptions): Signal<string | null>;
+function fragment(options?: FragmentOptions): WritableSignal<string | null>;
 ```
 
 ## Related


### PR DESCRIPTION
<!--
Thank you for your contribution to Signality!

Please follow these guidelines:
- Keep PRs focused: one feature, fix, or refactor per PR.
- Avoid large, mixed changes.
- Include tests for new utilities.
- Update documentation if adding new features.
-->

Closes: #154 <!-- Related issue number -->

## Summary

<!-- Briefly explain the purpose of the PR -->
This PR makes the `fragment` utility writable.

## What changed

<!-- Describe what was added, removed, or changed -->
- The `fragment` function now returns a `WritableSignal<string | null>` instead of `Signal<string | null>`.
  > When using `set` or `update`, it will automatically call for a navigation and update the url fragment.

- There is also a new option: `replaceUrl`.
  > It comes from [`NavigationExtras`](https://angular.dev/api/router/NavigationExtras#replaceUrl) and is passed down to it under the hood and it gives us the choice to replace the History#state instead of pushing a new entry.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable)
- [x] Follows existing code style and patterns

## Breaking changes

<!-- If applicable, describe breaking changes and required migration steps -->
<!-- Otherwise, write "None" -->
None

## Notes

<!-- Any additional context or implementation details -->
<!-- Optional -->
