### PR TITLE
fix(core): `textDirection` correctly sync initial state from the DOM for reactive targets

### DIFF
--- a/projects/core/browser/text-direction/index.ts
+++ b/projects/core/browser/text-direction/index.ts
@@ -1,4 +1,4 @@
-import { CreateSignalOptions, signal, WritableSignal } from '@angular/core';
+import { afterNextRender, CreateSignalOptions, signal, WritableSignal } from '@angular/core';
 import { createToken, setupContext } from '@signality/core/internal';
 import { toElement } from '@signality/core/utilities';
 import type { MaybeElementSignal, WithInjector } from '@signality/core/types';
@@ -46,33 +46,43 @@ export interface TextDirectionOptions extends CreateSignalOptions<TextDirection>
  */
 export function textDirection(options?: TextDirectionOptions): WritableSignal<TextDirection> {
   const { runInContext } = setupContext(options?.injector, textDirection);
-  const initialValue = options?.initialValue ?? 'ltr';
 
   return runInContext(({ isServer }) => {
+    const initialValue = options?.initialValue ?? 'ltr';
+
     if (isServer) {
       return signal(initialValue, options);
     }
 
     const target = options?.target ?? document.documentElement;
 
-    const readDir = (): TextDirection => {
+    const getDir = (): TextDirection => {
       const el = toElement(target);
       return (el?.getAttribute('dir') as TextDirection) || initialValue;
     };
 
-    const dir = signal<TextDirection>(readDir());
+    const setDir = (value: TextDirection) => {
+      const el = toElement(target);
+      el?.setAttribute('dir', value);
+    };
 
-    mutationObserver(target, () => dir.set(readDir()), {
+    const dir = signal<TextDirection>(initialValue);
+
+    mutationObserver(target, () => dir.set(getDir()), {
       attributes: true,
       attributeFilter: ['dir'],
+    });
+
+    afterNextRender({
+      earlyRead: () => dir.set(getDir()),
+      write: () => setDir(dir()),
     });
 
     return proxySignal(
       dir,
       {
         set: value => {
-          const el = toElement(target);
-          el?.setAttribute('dir', value);
+          setDir(value);
           dir.set(value);
         },
       },

--- a/projects/core/browser/text-direction/index.ts
+++ b/projects/core/browser/text-direction/index.ts
@@ -66,7 +66,7 @@ export function textDirection(options?: TextDirectionOptions): WritableSignal<Te
       el?.setAttribute('dir', value);
     };
 
-    const dir = signal<TextDirection>(initialValue);
+    const dir = signal<TextDirection>(getDir(), options);
 
     mutationObserver(target, () => dir.set(getDir()), {
       attributes: true,


### PR DESCRIPTION
Closes: #164