### PR TITLE
fix(core): improve type inference for `createInjectable` utility functions

### DIFF
--- a/projects/core/utilities/create-injectable.ts
+++ b/projects/core/utilities/create-injectable.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-function-type */
 import { inject, InjectionToken, InjectOptions, isDevMode, Provider } from '@angular/core';
 import { setupContext } from '@signality/core/internal';
 import type { WithInjector } from '@signality/core/types';
@@ -17,9 +18,11 @@ export type CreateInjectableRef<Arguments extends any[], InjectReturn> = Readonl
   ]
 >;
 
-type Factory<Arguments extends any[], Return> = (...args: Arguments) => Return;
-
-type OptionalArgs<Arguments extends any[]> = { [K in keyof Arguments]: Arguments[K] | undefined };
+// TypeScript doesn't infer the types correctly when using the `(...args: any[]) => any` + `ReturnType` and `Parameters` utility types.
+// Also, `ReturnType` and `Parameters` don't work with `Function`.
+// Therefore we need to create our own versions of these utilities that work with the `Function` type.
+export type Parameters<Factory> = Factory extends (...args: infer Params) => any ? Params : never;
+export type ReturnType<Factory> = Factory extends (...args: any[]) => infer Return ? Return : never;
 
 export interface CreateInjectableFn {
   /**
@@ -48,10 +51,10 @@ export interface CreateInjectableFn {
    * }
    * ```
    */
-  <Arguments extends any[], Return>(
-    description: string,
-    factory: Factory<Arguments, Return>
-  ): CreateInjectableRef<Arguments, Return>;
+  <Factory extends Function>(description: string, factory: Factory): CreateInjectableRef<
+    Parameters<Factory>,
+    ReturnType<Factory>
+  >;
 
   /**
    * Creates an injectable that is provided at the application root by default (`providedIn: 'root'`).
@@ -89,37 +92,36 @@ export interface CreateInjectableFn {
    * export class MyComponent {}
    * ```
    */
-  root: <Arguments extends any[], Return>(
+  root: <Factory extends Function>(
     description: string,
-    factory: (...args: OptionalArgs<Arguments>) => Return
-  ) => CreateInjectableRef<OptionalArgs<Arguments>, Return>;
+    factory: Factory
+  ) => CreateInjectableRef<Parameters<Factory>, ReturnType<Factory>>;
 }
 
 export const createInjectable: CreateInjectableFn = (() => {
   const fn = createInjectableFn as CreateInjectableFn;
-
-  fn.root = (description, factory) =>
-    createInjectableFn(description, factory as Factory<any[], any>, true) as any;
-
+  fn.root = (description, factory) => createInjectableFn(description, factory, true) as any;
   return fn;
 })();
 
-function createInjectableFn<Arguments extends any[], Return>(
+function createInjectableFn<Factory extends Function>(
   description: string,
-  factory: Factory<Arguments, Return>,
+  factory: Factory,
   root = false
-): CreateInjectableRef<Arguments, Return> {
-  const injectionToken = new InjectionToken<Return>(
+): CreateInjectableRef<Parameters<Factory>, ReturnType<Factory>> {
+  const injectionToken = new InjectionToken<ReturnType<Factory>>(
     isDevMode() ? description : '',
-    root ? { providedIn: 'root', factory } : undefined
+    root
+      ? { providedIn: 'root', factory: factory as unknown as () => ReturnType<Factory> }
+      : undefined
   );
 
-  function provideFn(...args: Arguments): Provider {
+  function provideFn(...args: Parameters<Factory>): Provider {
     return { provide: injectionToken, useFactory: () => factory(...args) };
   }
 
-  function injectFn(options?: Omit<InjectOptions, 'optional'> & WithInjector): Return;
-  function injectFn(options?: InjectOptions & WithInjector): Return | null {
+  function injectFn(options?: Omit<InjectOptions, 'optional'> & WithInjector): ReturnType<Factory>;
+  function injectFn(options?: InjectOptions & WithInjector): ReturnType<Factory> | null {
     const { injector, ...injectOptions } = options || {};
     const { runInContext } = setupContext(injector, injectFn);
     return runInContext(() => inject(injectionToken, injectOptions));

--- a/projects/docs/utilities/create-injectable.md
+++ b/projects/docs/utilities/create-injectable.md
@@ -102,6 +102,13 @@ export class StagingComponent {
 }
 ```
 
+:::warning If your factory function defines parameters (used by `provideFn`), ensure they are *optional* or have *default values*.
+
+Since `createInjectable.root` automatically provides the dependency at the root, the factory is executed without arguments by default.
+
+Explicitly invoking `provideFn(args)` is only needed for localized overrides or testing.
+:::
+
 ### Using with custom Injector
 
 The `injectFn` supports passing an explicit `Injector` if you need to inject the value outside of the typical injection context.

--- a/projects/docs/utilities/create-injectable.md
+++ b/projects/docs/utilities/create-injectable.md
@@ -121,6 +121,13 @@ export class ManualInjection {
 ## Type Definitions
 
 ```ts
+interface InjectFn<Return> {
+  (options?: Omit<InjectOptions, 'optional'> & WithInjector): Return;
+  (options?: InjectOptions & WithInjector): Return | null;
+}
+
+type ProvideFn<Arguments extends any[]> = (...args: Arguments) => Provider;
+
 type CreateInjectableRef<Arguments extends any[], InjectReturn> = Readonly<
   [
     injectFn: InjectFn<InjectReturn>,
@@ -130,15 +137,15 @@ type CreateInjectableRef<Arguments extends any[], InjectReturn> = Readonly<
 >;
 
 interface CreateInjectableFn {
-  <Arguments extends any[], Return>(
-    description: string,
-    factory: Factory<Arguments, Return>,
-  ): CreateInjectableRef<Arguments, Return>;
+  <Factory extends Function>(description: string, factory: Factory): CreateInjectableRef<
+    Parameters<Factory>,
+    ReturnType<Factory>
+  >;
 
-  root: <Arguments extends any[], Return>(
+  root: <Factory extends Function>(
     description: string,
-    factory: (...args: OptionalArgs<Arguments>) => Return,
-  ) => CreateInjectableRef<OptionalArgs<Arguments>, Return>;
+    factory: Factory
+  ) => CreateInjectableRef<Parameters<Factory>, ReturnType<Factory>>;
 }
 ```
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Signality!

Please follow these guidelines:
- Keep PRs focused: one feature, fix, or refactor per PR.
- Avoid large, mixed changes.
- Include tests for new utilities.
- Update documentation if adding new features.
-->

Closes: #184 <!-- Related issue number -->

## Summary

<!-- Briefly explain the purpose of the PR -->
This PR fixes the type inference for `createInjectable` and `createInjectable.root` when declaring parameters with default values.

Previously, the return type of `injectFn` and the expected argument type of `provideFn` would fall back to any. With this update, both types are now correctly inferred directly from the default value (e.g., if a `string` default is provided, `injectFn` returns `string` and `provideFn` expects `baseUrl?: string`).

## What changed

<!-- Describe what was added, removed, or changed -->
I replaced the `Arguments extends any[]` and `Return` generics in both `createInjectable` and `createInjectable.root` with a single `Factory extends Function` generic. Consequently, I updated the sections requiring argument and return types to use `Parameters<Factory>` and `ReturnType<Factory>`.

## Checklist

- [ ] Tests added/updated
- [x] Documentation updated (if applicable)
- [x] Follows existing code style and patterns

## Breaking changes

<!-- If applicable, describe breaking changes and required migration steps -->
<!-- Otherwise, write "None" -->
None

## Notes

<!-- Any additional context or implementation details -->
<!-- Optional -->
- Using `(...args: any[]) => any` instead of `Function` didn't solve the type inference issue.
- With `Factory`, using the built-in `Parameters` and `ReturnType` worked conceptually, but TypeScript raised an error. To keep the naming consistent and avoid overcomplicating the documentation type declarations for a weird TS quirk, I decided to shadow them with custom `Parameters` and `ReturnType` utility types that work perfectly with `Function`.
