### PR TITLE
fix(core): `storage` fall back to CustomEvent for non-built-in storage

### DIFF
--- a/projects/core/browser/storage/index.test.ts
+++ b/projects/core/browser/storage/index.test.ts
@@ -10,16 +10,23 @@ describe(storage.name, () => {
     mockLocalStorage = {};
     mockSessionStorage = {};
 
-    const createStorageMock = (store: Record<string, string>) => ({
-      getItem: jest.fn((key: string) => store[key] ?? null),
-      setItem: jest.fn((key: string, value: string) => (store[key] = value)),
-      removeItem: jest.fn((key: string) => delete store[key]),
-      clear: jest.fn(() => Object.keys(store).forEach(key => delete store[key])),
-      key: jest.fn((index: number) => Object.keys(store)[index] ?? null),
-      get length() {
-        return Object.keys(store).length;
-      },
-    });
+    const createStorageMock = (store: Record<string, string>) => {
+      const mock = {
+        getItem: jest.fn((key: string) => store[key] ?? null),
+        setItem: jest.fn((key: string, value: string) => (store[key] = value)),
+        removeItem: jest.fn((key: string) => delete store[key]),
+        clear: jest.fn(() => Object.keys(store).forEach(key => delete store[key])),
+        key: jest.fn((index: number) => Object.keys(store)[index] ?? null),
+        get length() {
+          return Object.keys(store).length;
+        },
+      };
+
+      // Make the mock a genuine `Storage` so `storage()` uses the native
+      // StorageEvent sync path (matches production localStorage/sessionStorage).
+      Object.setPrototypeOf(mock, Storage.prototype);
+      return mock;
+    };
 
     Object.defineProperty(window, 'localStorage', {
       writable: true,
@@ -348,6 +355,63 @@ describe(storage.name, () => {
       });
 
       window.dispatchEvent(storageEvent);
+
+      expect(component.shared()).toBe('updated');
+    });
+  });
+
+  describe('proxied storage (non-built-in)', () => {
+    // A plain object is NOT an `instanceof Storage`, mimicking a proxied or
+    // custom localStorage where a StorageEvent cannot be constructed. The outer
+    // beforeEach installs a genuine-Storage mock, so override it here.
+    beforeEach(() => {
+      Object.defineProperty(window, 'localStorage', {
+        configurable: true,
+        writable: true,
+        value: {
+          getItem: jest.fn((key: string) => mockLocalStorage[key] ?? null),
+          setItem: jest.fn((key: string, value: string) => (mockLocalStorage[key] = value)),
+          removeItem: jest.fn((key: string) => delete mockLocalStorage[key]),
+          clear: jest.fn(() =>
+            Object.keys(mockLocalStorage).forEach(key => delete mockLocalStorage[key])
+          ),
+          key: jest.fn((index: number) => Object.keys(mockLocalStorage)[index] ?? null),
+          get length() {
+            return Object.keys(mockLocalStorage).length;
+          },
+        },
+      });
+    });
+
+    @Component({ template: '' })
+    class TestComponent {
+      readonly shared = storage('shared', 'initial');
+    }
+
+    const createComponent = () => {
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+      return fixture.componentInstance;
+    };
+
+    it('should sync via CustomEvent when storage is not built-in', () => {
+      const component = createComponent();
+
+      expect(component.shared()).toBe('initial');
+
+      // The refactored code listens for a CustomEvent (not StorageEvent) when
+      // the storage is not an `instanceof Storage`.
+      // Event name must match STORAGE_EVENT_NAME in index.ts.
+      window.dispatchEvent(
+        new CustomEvent('signality-storage', {
+          detail: {
+            key: 'shared',
+            oldValue: 'initial',
+            newValue: 'updated',
+            storageArea: window.localStorage,
+          },
+        })
+      );
 
       expect(component.shared()).toBe('updated');
     });

--- a/projects/core/browser/storage/index.test.ts
+++ b/projects/core/browser/storage/index.test.ts
@@ -417,6 +417,34 @@ describe(storage.name, () => {
     });
   });
 
+  describe('same-document sync (built-in storage)', () => {
+    // Two signals bound to the same key in the same document stay in sync via the
+    // CustomEvent dispatched on write — the native `'storage'` event never fires
+    // in the writing document.
+    @Component({ template: '' })
+    class TestComponent {
+      readonly shared = storage('shared', 'initial');
+    }
+
+    const createComponent = () => {
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+      return fixture.componentInstance;
+    };
+
+    it('should sync sibling instances bound to the same key', () => {
+      const writer = createComponent();
+      const reader = createComponent();
+
+      expect(reader.shared()).toBe('initial');
+
+      writer.shared.set('updated');
+
+      expect(writer.shared()).toBe('updated');
+      expect(reader.shared()).toBe('updated');
+    });
+  });
+
   describe('custom serializer', () => {
     @Component({ template: '' })
     class TestComponent {

--- a/projects/core/browser/storage/index.ts
+++ b/projects/core/browser/storage/index.ts
@@ -78,6 +78,21 @@ export interface Serializer<T> {
 }
 
 /**
+ * Custom event dispatched to synchronize `storage` signals within the same
+ * document when the underlying storage is not a built-in `Storage` (e.g. a
+ * proxied localStorage), because a `StorageEvent` cannot be constructed with a
+ * non-built-in `storageArea`.
+ */
+const STORAGE_EVENT_NAME = 'signality-storage';
+
+interface StorageEventLike {
+  readonly key: string | null;
+  readonly oldValue: string | null;
+  readonly newValue: string | null;
+  readonly storageArea: Storage | null;
+}
+
+/**
  * Signal-based wrapper around the [Web Storage API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API) (localStorage/sessionStorage).
  *
  * @param key - Storage key (can be a signal for dynamic keys)
@@ -158,14 +173,12 @@ export function storage<T>(
       oldValue: string | null,
       newValue: string | null
     ) => {
+      const detail: StorageEventLike = { key, oldValue, newValue, storageArea: targetStorage };
+
       window.dispatchEvent(
-        new StorageEvent('storage', {
-          key,
-          oldValue,
-          newValue,
-          storageArea: targetStorage,
-          url: window.location.href,
-        })
+        targetStorage instanceof Storage
+          ? new StorageEvent('storage', { ...detail, url: window.location.href })
+          : new CustomEvent<StorageEventLike>(STORAGE_EVENT_NAME, { detail })
       );
     };
 
@@ -187,17 +200,25 @@ export function storage<T>(
 
     const source = signal<T>(readValue(toValue(key)), options);
 
+    const syncFromEvent = (event: StorageEventLike): void => {
+      const currKey = toValue(key);
+
+      if (event.key === currKey && event.storageArea === targetStorage) {
+        const newValue =
+          event.newValue === null ? initialValue : processValue(serializer.read(event.newValue));
+
+        source.set(newValue);
+      }
+    };
+
     setupSync(() => {
-      listener(window, 'storage', e => {
-        const currKey = toValue(key);
-
-        if (e.key === currKey && e.storageArea === targetStorage) {
-          const newValue =
-            e.newValue === null ? initialValue : processValue(serializer.read(e.newValue));
-
-          source.set(newValue);
-        }
-      });
+      if (targetStorage instanceof Storage) {
+        listener(window, 'storage', syncFromEvent);
+      } else {
+        listener(window, STORAGE_EVENT_NAME, event =>
+          syncFromEvent((event as CustomEvent<StorageEventLike>).detail)
+        );
+      }
     });
 
     if (isSignal(key)) {

--- a/projects/core/browser/storage/index.ts
+++ b/projects/core/browser/storage/index.ts
@@ -174,12 +174,7 @@ export function storage<T>(
       newValue: string | null
     ) => {
       const detail: StorageEventLike = { key, oldValue, newValue, storageArea: targetStorage };
-
-      window.dispatchEvent(
-        targetStorage instanceof Storage
-          ? new StorageEvent('storage', { ...detail, url: window.location.href })
-          : new CustomEvent<StorageEventLike>(STORAGE_EVENT_NAME, { detail })
-      );
+      window.dispatchEvent(new CustomEvent<StorageEventLike>(STORAGE_EVENT_NAME, { detail }));
     };
 
     const writeValue = (value: T): void => {
@@ -212,13 +207,16 @@ export function storage<T>(
     };
 
     setupSync(() => {
+      // cross-document (other tab) changes to a built-in Storage arrive as a
+      // native `'storage'` event fired by the browser.
       if (targetStorage instanceof Storage) {
         listener(window, 'storage', syncFromEvent);
-      } else {
-        listener(window, STORAGE_EVENT_NAME, event =>
-          syncFromEvent((event as CustomEvent<StorageEventLike>).detail)
-        );
       }
+
+      // same-document changes arrive as the CustomEvent dispatched on write.
+      listener<CustomEvent<StorageEventLike>>(window, STORAGE_EVENT_NAME, e =>
+        syncFromEvent(e.detail)
+      );
     });
 
     if (isSignal(key)) {


### PR DESCRIPTION
Closes: #197