### PR TITLE
fix(core): `resizeObserver` prevent observation from resuming after `destroy()`

### DIFF
--- a/projects/core/observers/resize-observer/index.ts
+++ b/projects/core/observers/resize-observer/index.ts
@@ -95,11 +95,15 @@ export function resizeObserver(
       });
     };
 
-    const destroy = () => observer?.disconnect();
+    const effectRef = afterRenderEffect({ read: setupObserver }, options);
+
+    const destroy = () => {
+      effectRef.destroy();
+      observer?.disconnect();
+      observer = null;
+    };
 
     onCleanup(destroy);
-
-    afterRenderEffect({ read: setupObserver }, options);
 
     return { destroy };
   });


### PR DESCRIPTION
Closes: #222