### PR TITLE
feat(core): `broadcastChannel` now supports signal options for the `data` signal

### DIFF
--- a/projects/core/browser/broadcast-channel/index.ts
+++ b/projects/core/browser/broadcast-channel/index.ts
@@ -1,9 +1,9 @@
-import { type Signal, signal } from '@angular/core';
+import { type CreateSignalOptions, type Signal, signal } from '@angular/core';
 import { constSignal, NOOP_FN, setupContext } from '@signality/core/internal';
 import type { WithInjector } from '@signality/core/types';
 import { listener, setupSync } from '@signality/core/browser/listener';
 
-export type BroadcastChannelOptions = WithInjector;
+export type BroadcastChannelOptions<T> = CreateSignalOptions<T | null> & WithInjector;
 
 export interface BroadcastChannelRef<T> {
   /** Last received data */
@@ -50,7 +50,7 @@ export interface BroadcastChannelRef<T> {
  */
 export function broadcastChannel<T>(
   name: string,
-  options?: BroadcastChannelOptions
+  options?: BroadcastChannelOptions<T>
 ): BroadcastChannelRef<T> {
   const { runInContext } = setupContext(options?.injector, broadcastChannel);
 
@@ -65,7 +65,7 @@ export function broadcastChannel<T>(
       };
     }
 
-    const data = signal<T | null>(null);
+    const data = signal<T | null>(null, options);
     const error = signal<MessageEvent | null>(null);
     const isClosed = signal(false);
 

--- a/projects/docs/browser/broadcast-channel.md
+++ b/projects/docs/browser/broadcast-channel.md
@@ -33,18 +33,20 @@ export class SyncedInput {
 
 ## Parameters
 
-| Parameter | Type                      | Description                                            |
-|-----------|---------------------------|--------------------------------------------------------|
-| `name`    | `string`                  | Channel name (must match across tabs)                  |
-| `options` | `BroadcastChannelOptions` | Optional configuration (see [Options](#options) below) |
+| Parameter | Type                         | Description                                            |
+|-----------|------------------------------|--------------------------------------------------------|
+| `name`    | `string`                     | Channel name (must match across tabs)                  |
+| `options` | `BroadcastChannelOptions<T>` | Optional configuration (see [Options](#options) below) |
 
 ## Options
 
-The `BroadcastChannelOptions` extends `WithInjector`:
+The `BroadcastChannelOptions<T>` extends [`CreateSignalOptions<T | null>`](https://angular.dev/api/core/CreateSignalOptions) and `WithInjector`:
 
-| Option     | Type                                                | Description                      |
-|------------|-----------------------------------------------------|----------------------------------|
-| `injector` | [`Injector`](https://angular.dev/api/core/Injector) | Optional injector for DI context |
+| Option      | Type                                                                         | Description                                                                                        |
+|-------------|------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
+| `equal`     | [`ValueEqualityFn<T \| null>`](https://angular.dev/api/core/ValueEqualityFn) | Custom equality function ([see more](https://angular.dev/guide/signals#signal-equality-functions)) |
+| `debugName` | `string`                                                                     | Debug name for the `data` signal (development only)                                                |
+| `injector`  | [`Injector`](https://angular.dev/api/core/Injector)                          | Optional injector for DI context                                                                   |
 
 ## Return Value
 
@@ -132,7 +134,7 @@ On the server, signals initialize with safe defaults:
 ## Type Definitions
 
 ```typescript
-type BroadcastChannelOptions = WithInjector;
+type BroadcastChannelOptions<T> = CreateSignalOptions<T | null> & WithInjector;
 
 interface BroadcastChannelRef<T> {
   readonly data: Signal<T | null>;
@@ -144,6 +146,6 @@ interface BroadcastChannelRef<T> {
 
 function broadcastChannel<T>(
   name: string,
-  options?: BroadcastChannelOptions,
+  options?: BroadcastChannelOptions<T>,
 ): BroadcastChannelRef<T>;
 ```


### PR DESCRIPTION
Closes: #224