### PR TITLE
feat(core)!: `windowSize` expose `width` and `height` as separate sig…

### DIFF
--- a/projects/core/browser/window-size/index.ts
+++ b/projects/core/browser/window-size/index.ts
@@ -1,11 +1,11 @@
-import { afterNextRender, type CreateSignalOptions, type Signal, signal } from '@angular/core';
+import { afterNextRender, type Signal, signal } from '@angular/core';
 import { constSignal, createToken, setupContext } from '@signality/core/internal';
 import type { WithInjector } from '@signality/core/types';
 import { listener } from '@signality/core/browser/listener';
 import { watcher } from '@signality/core/reactivity/watcher';
 import { mediaQuery } from '@signality/core/browser/media-query';
 
-export interface WindowSizeOptions extends CreateSignalOptions<WindowSizeValue>, WithInjector {
+export interface WindowSizeOptions extends WithInjector {
   /**
    * Include scrollbar in dimensions calculation.
    *
@@ -26,19 +26,35 @@ export interface WindowSizeValue {
   readonly height: number;
 }
 
+export interface WindowSizeRef {
+  /**
+   * Viewport width. Excludes the scrollbar unless `includeScrollbar` is enabled.
+   */
+  readonly width: Signal<number>;
+
+  /**
+   * Viewport height. Excludes the scrollbar unless `includeScrollbar` is enabled.
+   */
+  readonly height: Signal<number>;
+}
+
 /**
  * Signal-based wrapper around the [Window API](https://developer.mozilla.org/en-US/docs/Web/API/Window) dimensions.
  *
+ * Width and height are separate signals, so consumers depending on one axis are
+ * not invalidated when only the other changes — e.g. a width-based breakpoint is
+ * unaffected by the mobile keyboard shrinking the viewport height.
+ *
  * @param options - Optional configuration including initialValue for SSR
- * @returns A signal containing the current window dimensions
+ * @returns A WindowSizeRef with width and height signals
  *
  * @example
  * ```typescript
  * @Component({
  *   template: `
  *     <div>
- *       Window: {{ size().width }} × {{ size().height }}px
- *       @if (size().width < 768) {
+ *       Window: {{ size.width() }} × {{ size.height() }}px
+ *       @if (size.width() < 768) {
  *         <p>Mobile view</p>
  *       }
  *     </div>
@@ -49,24 +65,26 @@ export interface WindowSizeValue {
  * }
  * ```
  */
-export function windowSize(options?: WindowSizeOptions): Signal<WindowSizeValue> {
+export function windowSize(options?: WindowSizeOptions): WindowSizeRef {
   const { runInContext } = setupContext(options?.injector, windowSize);
   const initialValue = options?.initialValue ?? DEFAULT_VALUE;
 
   return runInContext(({ isServer }) => {
     if (isServer) {
-      return constSignal(initialValue);
+      return {
+        width: constSignal(initialValue.width),
+        height: constSignal(initialValue.height),
+      };
     }
 
     const includeScrollbar = options?.includeScrollbar ?? false;
 
-    const size = signal<WindowSizeValue>(initialValue, options);
+    const width = signal(initialValue.width);
+    const height = signal(initialValue.height);
 
     const update = () => {
-      const width = includeScrollbar ? window.innerWidth : document.documentElement.clientWidth;
-      const height = includeScrollbar ? window.innerHeight : document.documentElement.clientHeight;
-
-      size.set({ width, height });
+      width.set(includeScrollbar ? window.innerWidth : document.documentElement.clientWidth);
+      height.set(includeScrollbar ? window.innerHeight : document.documentElement.clientHeight);
     };
 
     listener(window, 'resize', update);
@@ -75,7 +93,10 @@ export function windowSize(options?: WindowSizeOptions): Signal<WindowSizeValue>
 
     afterNextRender({ read: update });
 
-    return size.asReadonly();
+    return {
+      width: width.asReadonly(),
+      height: height.asReadonly(),
+    };
   });
 }
 

--- a/projects/demos/src/demos/window-size/window-size-demo.html
+++ b/projects/demos/src/demos/window-size/window-size-demo.html
@@ -4,11 +4,11 @@
     <div class="ws-rows">
       <div class="ws-row">
         <span class="ws-label">Width</span>
-        <span class="ws-value">{{ size().width }}px</span>
+        <span class="ws-value">{{ size.width() }}px</span>
       </div>
       <div class="ws-row">
         <span class="ws-label">Height</span>
-        <span class="ws-value">{{ size().height }}px</span>
+        <span class="ws-value">{{ size.height() }}px</span>
       </div>
     </div>
   </demo-card>

--- a/projects/docs/browser/window-size.md
+++ b/projects/docs/browser/window-size.md
@@ -16,7 +16,7 @@ import { windowSize } from '@signality/core';
 
 @Component({
   template: `
-    <p>Window: {{ size().width }} × {{ size().height }}</p>
+    <p>Window: {{ size.width() }} × {{ size.height() }}</p>
   `,
 })
 export class WindowSizeDemo {
@@ -24,7 +24,8 @@ export class WindowSizeDemo {
 }
 ```
 
-::: warning Use InjectionToken for Singleton
+::: warning Use InjectionToken for Singleton 
+
 For global state tracking like `windowSize`, consider using the provided `WINDOW_SIZE` token instead of calling the function directly. This provides a singleton instance that can be shared across your entire application, reducing memory usage and event listener overhead:
 
 ```typescript
@@ -46,31 +47,22 @@ Learn more about [Token-based utilities](/guide/key-concepts#token-based-utiliti
 
 ## Options
 
-The `WindowSizeOptions` extends [`CreateSignalOptions<WindowSizeValue>`](https://angular.dev/api/core/CreateSignalOptions) and `WithInjector`:
+The `WindowSizeOptions` extends `WithInjector`:
 
-| Option             | Type                                                                               | Default                   | Description                                                                                        |
-|--------------------|------------------------------------------------------------------------------------|---------------------------|----------------------------------------------------------------------------------------------------|
-| `includeScrollbar` | `boolean`                                                                          | `false`                   | Include scrollbar in dimensions                                                                    |
-| `initialValue`     | `WindowSizeValue`                                                                  | `{ width: 0, height: 0 }` | Initial value for SSR and before the first measurement                                             |
-| `equal`            | [`ValueEqualityFn<WindowSizeValue>`](https://angular.dev/api/core/ValueEqualityFn) | -                         | Custom equality function ([see more](https://angular.dev/guide/signals#signal-equality-functions)) |
-| `debugName`        | `string`                                                                           | -                         | Debug name for the signal (development only)                                                       |
-| `injector`         | [`Injector`](https://angular.dev/api/core/Injector)                                | -                         | Optional injector for DI context                                                                   |
+| Option             | Type                                                | Default                   | Description                                            |
+|--------------------|-----------------------------------------------------|---------------------------|--------------------------------------------------------|
+| `includeScrollbar` | `boolean`                                           | `false`                   | Include scrollbar in dimensions                        |
+| `initialValue`     | `WindowSizeValue`                                   | `{ width: 0, height: 0 }` | Initial value for SSR and before the first measurement |
+| `injector`         | [`Injector`](https://angular.dev/api/core/Injector) | -                         | Optional injector for DI context                       |
 
 ## Return Value
 
-The `windowSize()` function returns a `Signal<WindowSizeValue>`:
+The `windowSize()` function returns a `WindowSizeRef`:
 
-```typescript
-interface WindowSizeValue {
-  readonly width: number;
-  readonly height: number;
-}
-```
-
-| Property | Description                                                                                                                      |
-|----------|----------------------------------------------------------------------------------------------------------------------------------|
-| `width`  | Viewport width — excludes scrollbar by default; includes scrollbar when `includeScrollbar: true`  |
-| `height` | Viewport height — excludes scrollbar by default; includes scrollbar when `includeScrollbar: true` |
+| Property | Type             | Description                                                                                       |
+|----------|------------------|---------------------------------------------------------------------------------------------------|
+| `width`  | `Signal<number>` | Viewport width — excludes scrollbar by default; includes scrollbar when `includeScrollbar: true`  |
+| `height` | `Signal<number>` | Viewport height — excludes scrollbar by default; includes scrollbar when `includeScrollbar: true` |
 
 ## Examples
 
@@ -90,7 +82,7 @@ import { windowSize } from '@signality/core';
 export class OrientationAware {
   readonly size = windowSize();
 
-  readonly isPortrait = computed(() => this.size().height > this.size().width);
+  readonly isPortrait = computed(() => this.size.height() > this.size.width());
 
   readonly orientation = computed(() => {
     return this.isPortrait() ? 'portrait' : 'landscape'; // [!code highlight]
@@ -115,10 +107,9 @@ export class FullscreenCanvas {
   constructor() {
     effect(() => {
       const canvasEl = this.canvas().nativeElement;
-      const { width, height } = this.size();
 
-      canvasEl.width = width;
-      canvasEl.height = height;
+      canvasEl.width = this.size.width();
+      canvasEl.height = this.size.height();
 
       this.redraw();
     });
@@ -132,7 +123,7 @@ export class FullscreenCanvas {
 
 ## SSR Compatibility
 
-On the server, the signal initializes with `initialValue` (defaults to `{ width: 0, height: 0 }`).
+On the server, both signals initialize from `initialValue` (defaults to `{ width: 0, height: 0 }`).
 
 ## Type Definitions
 
@@ -142,14 +133,19 @@ interface WindowSizeValue {
   readonly height: number;
 }
 
-interface WindowSizeOptions extends CreateSignalOptions<WindowSizeValue>, WithInjector {
+interface WindowSizeOptions extends WithInjector {
   readonly includeScrollbar?: boolean;
   readonly initialValue?: WindowSizeValue;
 }
 
-function windowSize(options?: WindowSizeOptions): Signal<WindowSizeValue>;
+interface WindowSizeRef {
+  readonly width: Signal<number>;
+  readonly height: Signal<number>;
+}
 
-const WINDOW_SIZE: InjectionToken<Signal<WindowSizeValue>>;
+function windowSize(options?: WindowSizeOptions): WindowSizeRef;
+
+const WINDOW_SIZE: InjectionToken<WindowSizeRef>;
 ```
 
 ## Related


### PR DESCRIPTION
Closes: #242 

## Breaking changes

`windowSize()` now returns a `WindowSizeRef` with two separate signals instead of a single `Signal<WindowSizeValue>`. The `WINDOW_SIZE` token is retyped accordingly.

**Before:**

```ts
readonly size = windowSize();

// template / code
{{ size().width }} × {{ size().height }}
const isMobile = computed(() => this.size().width < 768);
```

**After:**

```ts
readonly size = windowSize();

// template / code
{{ size.width() }} × {{ size.height() }}
const isMobile = computed(() => this.size.width() < 768);
```

**Migration:** replace every `size().width` with `size.width()` and `size().height` with `size.height()` - a mechanical find-and-replace; no logic changes are required. Destructuring also works: const `{ width, height } = windowSize()`.

WindowSizeOptions no longer extends CreateSignalOptions:

- `equal` - removed. Both signals are numbers, so the default Object.is equality is already exact; a same-value update no longer notifies at all.
- `debugName` - removed, since a single name cannot label two signals.
- `initialValue` and `includeScrollbar` are unchanged.

`WindowSizeValue` is still exported and is now used only as the `initialValue` shape.