### PR TITLE
fix(core): `eyeDropper` keep the latest abort controller when an earlier open settles

### DIFF
--- a/projects/core/browser/eye-dropper/index.ts
+++ b/projects/core/browser/eye-dropper/index.ts
@@ -99,8 +99,6 @@ export function eyeDropper(options?: EyeDropperOptions): EyeDropperRef {
         if ((error as Error).name !== 'AbortError') {
           throw error;
         }
-      } finally {
-        abortController = null;
       }
     };
 


### PR DESCRIPTION
Closes: #249